### PR TITLE
test: Verify pull_request_target trigger for evaluate-pr-tests

### DIFF
--- a/src/Controls/tests/Core.UnitTests/PullRequestTargetTriggerTest.cs
+++ b/src/Controls/tests/Core.UnitTests/PullRequestTargetTriggerTest.cs
@@ -1,0 +1,11 @@
+// Test file to trigger evaluate-pr-tests workflow via pull_request_target
+namespace Microsoft.Maui.Controls.Core.UnitTests;
+
+public class PullRequestTargetTriggerTest
+{
+	[Fact]
+	public void DummyTestForPRTTrigger()
+	{
+		Assert.True(true);
+	}
+}


### PR DESCRIPTION
Tests that the workflow triggers correctly with pull_request_target instead of pull_request. This is a cross-fork PR from kubaflo to verify fork PR support before applying to dotnet/maui.